### PR TITLE
11 reestructurar carpetas

### DIFF
--- a/backend/internal/handler/handler.go
+++ b/backend/internal/handler/handler.go
@@ -9,7 +9,7 @@ import (
 	"gonum.org/v1/gonum/mat"
 )
 
-func process() func(c *gin.Context) {
+func Process() func(c *gin.Context) {
 	return func(c *gin.Context) {
 		var req models.SimplexRequest
 		if err := c.ShouldBindJSON(&req); err != nil {

--- a/backend/internal/handler/handler.go
+++ b/backend/internal/handler/handler.go
@@ -1,7 +1,8 @@
-package main
+package handler
 
 import (
 	"autosimplex/internal/models"
+	"autosimplex/internal/simplex"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -34,7 +35,7 @@ func process() func(c *gin.Context) {
 		}
 		constraintMatrix := mat.NewDense(rows, cols, vars)
 
-		result, solution := Solve(objective, constraintMatrix)
+		result, solution := simplex.Solve(objective, constraintMatrix)
 
 		c.JSON(http.StatusOK, gin.H{
 			"optimal_value": result,

--- a/backend/internal/handler/handler_test.go
+++ b/backend/internal/handler/handler_test.go
@@ -1,4 +1,4 @@
-package main
+package handler
 
 import (
 	"bytes"

--- a/backend/internal/handler/handler_test.go
+++ b/backend/internal/handler/handler_test.go
@@ -14,7 +14,7 @@ import (
 func TestProcess_ValidRequest(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
-	router.POST("/process", process())
+	router.POST("/process", Process())
 
 	body, _ := json.Marshal(map[string]interface{}{
 		"objective": map[string]interface{}{
@@ -44,7 +44,7 @@ func TestProcess_ValidRequest(t *testing.T) {
 func TestProcess_InvalidConstraints(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
-	router.POST("/process", process())
+	router.POST("/process", Process())
 
 	// filas y columnas no coinciden con cantidad de vars
 	body, _ := json.Marshal(map[string]interface{}{
@@ -74,7 +74,7 @@ func TestProcess_InvalidConstraints(t *testing.T) {
 func TestProcess_InvalidObjective(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
-	router.POST("/process", process())
+	router.POST("/process", Process())
 
 	body, _ := json.Marshal(map[string]interface{}{
 		"objective": map[string]interface{}{
@@ -103,7 +103,7 @@ func TestProcess_InvalidObjective(t *testing.T) {
 func TestProcess_InvalidJSON(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
-	router.POST("/process", process())
+	router.POST("/process", Process())
 
 	body := []byte(`{"objective": {"n": 2, "coefficients": [1, "bad"]}, "constraints": {"rows": 1, "cols": 1, "vars": [1]}}`)
 

--- a/backend/internal/handler/validations.go
+++ b/backend/internal/handler/validations.go
@@ -1,4 +1,4 @@
-package main
+package handler
 
 import (
 	"fmt"

--- a/backend/internal/simplex/simplex.go
+++ b/backend/internal/simplex/simplex.go
@@ -1,4 +1,4 @@
-package main
+package simplex
 
 import (
 	"fmt"

--- a/backend/internal/simplex/simplex_test.go
+++ b/backend/internal/simplex/simplex_test.go
@@ -1,4 +1,4 @@
-package main
+package simplex
 
 import (
 	"testing"

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,13 +1,15 @@
 package main
 
 import (
+	"autosimplex/internal/handler"
+
 	"github.com/gin-gonic/gin"
 )
 
 func main() {
 	r := gin.Default()
 
-	r.POST("/process", process())
+	r.POST("/process", handler.Process())
 
 	if err := r.Run(":8080"); err != nil {
 		panic("Error al iniciar el servidor: " + err.Error())


### PR DESCRIPTION
This pull request refactors the backend codebase to improve organization and maintainability by introducing internal packages and updating references throughout the project. The main changes include moving handler and simplex logic into their respective packages, updating import paths, and renaming files to match the new structure.

**Codebase organization:**

* Moved handler logic from `backend/handler.go` and `backend/handler_test.go` to `backend/internal/handler/handler.go` and `backend/internal/handler/handler_test.go`, and updated the package name to `handler`. [[1]](diffhunk://#diff-2786da2ed265f9c43fe73da5acdebcfe0b1cf9494cf740d63f3f9382ad1de9b3L1-R12) [[2]](diffhunk://#diff-950bfcb678580880e100bd429b53509739a882d1d2cbcc5c20a15fefd63b8d2bL1-R1)
* Moved validation logic from `backend/validations.go` to `backend/internal/handler/validations.go`, updating the package name to `handler`.
* Moved simplex algorithm implementation and tests from `backend/simplex.go` and `backend/simplex_test.go` to `backend/internal/simplex/simplex.go` and `backend/internal/simplex/simplex_test.go`, updating the package name to `simplex`. [[1]](diffhunk://#diff-f2859a650caee8fd02df66b413f5dbbf41a7284811bf55fbff4a01ee8f00daf4L1-R1) [[2]](diffhunk://#diff-ca3659a150f02fc2ec64f5e0bf5c363c8d7ad1d7109f8546a442601e56ea7bdbL1-R1)

**Reference updates:**

* Updated all references to the handler and simplex functions to use the new package paths, including changing calls to `process()` to `handler.Process()` in `backend/main.go` and test files. [[1]](diffhunk://#diff-dec704b60ebde2632503812758e7db9b3b1f663f8b1ac015e670644b5396a2f0R4-R12) [[2]](diffhunk://#diff-950bfcb678580880e100bd429b53509739a882d1d2cbcc5c20a15fefd63b8d2bL17-R17) [[3]](diffhunk://#diff-950bfcb678580880e100bd429b53509739a882d1d2cbcc5c20a15fefd63b8d2bL47-R47) [[4]](diffhunk://#diff-950bfcb678580880e100bd429b53509739a882d1d2cbcc5c20a15fefd63b8d2bL77-R77) [[5]](diffhunk://#diff-950bfcb678580880e100bd429b53509739a882d1d2cbcc5c20a15fefd63b8d2bL106-R106) [[6]](diffhunk://#diff-2786da2ed265f9c43fe73da5acdebcfe0b1cf9494cf740d63f3f9382ad1de9b3L37-R38)

These changes make the codebase more modular and easier to maintain by clearly separating concerns into internal packages.