### PR TITLE
Retornar warnings

### DIFF
--- a/backend/internal/handler/handler.go
+++ b/backend/internal/handler/handler.go
@@ -59,7 +59,7 @@ func Process() func(c *gin.Context) {
 			}
 		}
 
-		result, solution, steps := simplex.SolveWithSigns(maximizeVec, constraintMatrix, signs)
+		result, solution, steps, warning := simplex.SolveWithSigns(maximizeVec, constraintMatrix, signs)
 
 		// If it was a minimization request, invert the returned optimal value
 		// because we solved the equivalent maximization of -c.
@@ -82,6 +82,7 @@ func Process() func(c *gin.Context) {
 			"optimal_value": result,
 			"solution":      solution,
 			"steps":         steps,
+			"warning":       warning,
 		})
 	}
 }

--- a/backend/internal/handler/handler_test.go
+++ b/backend/internal/handler/handler_test.go
@@ -165,7 +165,7 @@ func TestProcess_MinimizeHandlerMatchesManualConversion(t *testing.T) {
 	// Manual conversion: Solve with maximize vector = -coefs, then invert sign
 	maximizeVec := mat.NewVecDense(3, []float64{-5, -4, -3})
 	constraintMatrix := mat.NewDense(3, 4, constraintsVars)
-	manualMax, _, _ := simplex.Solve(maximizeVec, constraintMatrix)
+	manualMax, _, _, _ := simplex.Solve(maximizeVec, constraintMatrix)
 	expectedMin := -manualMax
 
 	// Response optimal_value is float64
@@ -215,7 +215,7 @@ func TestProcess_MinimizeWithGreaterEqual(t *testing.T) {
 	// then invert the result
 	maximizeVec := mat.NewVecDense(2, []float64{-4, -5})
 	constraintMatrix := mat.NewDense(2, 3, constraintsVars)
-	manualMax, _, _ := simplex.SolveWithSigns(maximizeVec, constraintMatrix, signs)
+	manualMax, _, _, _ := simplex.SolveWithSigns(maximizeVec, constraintMatrix, signs)
 	expectedMin := -manualMax
 
 	val, ok := resp["optimal_value"].(float64)

--- a/backend/internal/simplex/simplex_signs_test.go
+++ b/backend/internal/simplex/simplex_signs_test.go
@@ -17,7 +17,7 @@ func TestSimplexEqualityConstraint(t *testing.T) {
 
 	signs := []string{"="}
 
-	result, sol, _ := SolveWithSigns(maximize, constraints, signs)
+	result, sol, _, _ := SolveWithSigns(maximize, constraints, signs)
 
 	expected := 12.0
 	if result != expected {
@@ -47,7 +47,7 @@ func TestSimplexGreaterEqualConstraint(t *testing.T) {
 
 	signs := []string{">=", "<=", "<="}
 
-	result, sol, _ := SolveWithSigns(maximize, constraints, signs)
+	result, sol, _, _ := SolveWithSigns(maximize, constraints, signs)
 
 	expected := 7.0
 	if result != expected {

--- a/backend/internal/simplex/simplex_test.go
+++ b/backend/internal/simplex/simplex_test.go
@@ -27,7 +27,7 @@ func TestSimplexPositives(t *testing.T) {
 		4, 1, 2, 11,
 		3, 4, 2, 8})
 
-	actualResult, _, _ := Solve(maximize, constraints)
+	actualResult, _, _, _ := Solve(maximize, constraints)
 	var expectedResult float64 = 13
 
 	if actualResult != expectedResult {
@@ -43,7 +43,7 @@ func TestSimplexNegatives(t *testing.T) {
 		2, -3, -1, -7, 1,
 		2, 1, 1, 3, 3})
 
-	actualResult, _, _ := Solve(maximize, constraints)
+	actualResult, _, _, _ := Solve(maximize, constraints)
 	var expectedResult float64 = 7
 
 	if actualResult != expectedResult {
@@ -60,7 +60,7 @@ func TestSimplexFractions(t *testing.T) {
 		0, 1, 1, .8, 7,
 		1, 5, 2.1, 3, 13})
 
-	actualResult, actualSolution, _ := Solve(maximize, constraints)
+	actualResult, actualSolution, _, _ := Solve(maximize, constraints)
 	var expectedResult = 12.8
 	var expectedSolution = []float64{4, 0, 0, 0}
 


### PR DESCRIPTION
This pull request enhances error handling and user feedback in the simplex solver by updating the `Solve` and `SolveWithSigns` functions to return a warning message alongside the solution. The handler and related tests are updated to accommodate this new return value, ensuring that any issues encountered during solving (such as malformed input or infeasible problems) are clearly communicated.

**Simplex solver improvements:**

* Modified `Solve` and `SolveWithSigns` in `simplex.go` to return a fourth value: a warning string describing errors or special conditions (e.g., malformed matrices, infeasible or unbounded problems). This string is set appropriately throughout the solving process. [[1]](diffhunk://#diff-f2859a650caee8fd02df66b413f5dbbf41a7284811bf55fbff4a01ee8f00daf4L11-R11) [[2]](diffhunk://#diff-f2859a650caee8fd02df66b413f5dbbf41a7284811bf55fbff4a01ee8f00daf4L23-R31) [[3]](diffhunk://#diff-f2859a650caee8fd02df66b413f5dbbf41a7284811bf55fbff4a01ee8f00daf4L144-R145) [[4]](diffhunk://#diff-f2859a650caee8fd02df66b413f5dbbf41a7284811bf55fbff4a01ee8f00daf4L212-R215) [[5]](diffhunk://#diff-f2859a650caee8fd02df66b413f5dbbf41a7284811bf55fbff4a01ee8f00daf4L229-R233) [[6]](diffhunk://#diff-f2859a650caee8fd02df66b413f5dbbf41a7284811bf55fbff4a01ee8f00daf4L269-R273)

**Handler and API changes:**

* Updated the `Process` handler in `handler.go` to extract and include the new `warning` value in the API response, allowing users to receive solver warnings directly. [[1]](diffhunk://#diff-2786da2ed265f9c43fe73da5acdebcfe0b1cf9494cf740d63f3f9382ad1de9b3L62-R62) [[2]](diffhunk://#diff-2786da2ed265f9c43fe73da5acdebcfe0b1cf9494cf740d63f3f9382ad1de9b3R85)

Closes #49.

**Test updates:**

* Refactored all calls to `Solve` and `SolveWithSigns` in tests to handle the new four-return-value signature, ensuring test coverage remains accurate and up-to-date. [[1]](diffhunk://#diff-950bfcb678580880e100bd429b53509739a882d1d2cbcc5c20a15fefd63b8d2bL168-R168) [[2]](diffhunk://#diff-950bfcb678580880e100bd429b53509739a882d1d2cbcc5c20a15fefd63b8d2bL218-R218) [[3]](diffhunk://#diff-e109936023d3fb9503b729831e27e519c83e2917e3747f9be593fe2c6e20314bL20-R20) [[4]](diffhunk://#diff-e109936023d3fb9503b729831e27e519c83e2917e3747f9be593fe2c6e20314bL50-R50) [[5]](diffhunk://#diff-ca3659a150f02fc2ec64f5e0bf5c363c8d7ad1d7109f8546a442601e56ea7bdbL30-R30) [[6]](diffhunk://#diff-ca3659a150f02fc2ec64f5e0bf5c363c8d7ad1d7109f8546a442601e56ea7bdbL46-R46) [[7]](diffhunk://#diff-ca3659a150f02fc2ec64f5e0bf5c363c8d7ad1d7109f8546a442601e56ea7bdbL63-R63)